### PR TITLE
Missing defaults when form control errors is null in FormFieldEmptyContainerDirective

### DIFF
--- a/projects/xtream/ngx-validation-errors/src/lib/form-field-empty-container.directive.ts
+++ b/projects/xtream/ngx-validation-errors/src/lib/form-field-empty-container.directive.ts
@@ -49,7 +49,7 @@ export class FormFieldEmptyContainerDirective implements DoCheck {
     const hasError = (!this.formControl.valid && this.formControl.touched) && !this.validationDisabled;
     let messages;
     if (hasError) {
-      messages = Object.keys(this.formControl.errors).map(error => {
+      messages = Object.keys(this.formControl.errors || {}).map(error => {
         const fieldName = this.formControlName;
         const errorKey = `${toScreamingSnakeCase(fieldName)}.ERRORS.${toScreamingSnakeCase(error)}`;
         if (this.messageProvider &&
@@ -59,7 +59,7 @@ export class FormFieldEmptyContainerDirective implements DoCheck {
           return `${this.validationContext}.${errorKey}`;
         }
       });
-      const params = Object.values(this.formControl.errors).reduce((a, b) => {
+      const params = Object.values(this.formControl.errors || {}).reduce((a, b) => {
         a = {...a, ...b};
         return a;
       }, {});


### PR DESCRIPTION
When form control errors map is null, an exception is thrown in the ngDoCheck method of the FormFieldEmptyContainerDirective.
This PR adds empty fallback object to prevent it.